### PR TITLE
Prevent missing `sitekey` when using multiple

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -111,9 +111,8 @@ class Captcha
         }
         if ($isMultiple) {
             array_push($this->captchaAttributes, $attributes);
-        } else {
-            $attributes['data-sitekey'] = $this->optionOrConfig($options, 'sitekey');
         }
+        $attributes['data-sitekey'] = $this->optionOrConfig($options, 'sitekey');
 
         return $html . '<div class="h-captcha"' . $this->buildAttributes($attributes) . '></div>';
     }


### PR DESCRIPTION
The h-captcha div is missing `site-key` when using multiple option, causing the following error on browser console:

> hcaptcha.js:1 [hCaptcha] Missing sitekey - https://hcaptcha.com/docs/configuration#jsapi